### PR TITLE
chore: prepare `v1.0.0-rc1` release

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 # The KYVE Network
 
-###### v1.0.0-rc0
+###### v1.0.0-rc1
 
 The KYVE consensus layer is the backbone of the KYVE ecosystem. The layer is a
 sovereign Delegated Proof of Stake network built using the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## [Unreleased]
 
+## [v1.0.0-rc1](https://github.com/KYVENetwork/chain/releases/tag/v1.0.0-rc1) - 2023-03-07
+
 ### Improvements
 
 - (deps) [#3](https://github.com/KYVENetwork/chain/pull/3), [#7](https://github.com/KYVENetwork/chain/pull/7) Bump Cosmos SDK to [v0.46.10](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.10) ([`v0.46.10-kyve-rc0`](https://github.com/KYVENetwork/cosmos-sdk/releases/tag/v0.46.10-kyve-rc0)).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMMIT := $(shell git log -1 --format='%H')
-VERSION := v1.0.0-rc0 # $(shell echo $(shell git describe --tags) | sed 's/^v//')
+VERSION := v1.0.0-rc1 # $(shell echo $(shell git describe --tags) | sed 's/^v//')
 
 DENOM ?= ukyve
 TEAM_TGE ?= 2023-03-14T14:03:14


### PR DESCRIPTION
These are the final needed changes before we can cut the `v1.0.0-rc1` tag.