### PR TITLE
fix: change ordering of events when submitting a bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # CHANGELOG
 
+### API Breaking
+
+- (`x/bundles`) [#42](https://github.com/KYVENetwork/chain/pull/42) Emit VoteEvent after BundleProposedEvent on bundle upload.
+
 ## [Unreleased]
 
 ## [v1.1.1](https://github.com/KYVENetwork/chain/releases/tag/v1.1.1) - 2023-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 
 # CHANGELOG
 
+## [Unreleased]
+
 ### API Breaking
 
-- (`x/bundles`) [#42](https://github.com/KYVENetwork/chain/pull/42) Emit VoteEvent after BundleProposedEvent on bundle upload.
-
-## [Unreleased]
+- (`x/bundles`) [#42](https://github.com/KYVENetwork/chain/pull/42) Emit `VoteEvent` after `BundleProposedEvent` when submitting a bundle.
 
 ## [v1.1.1](https://github.com/KYVENetwork/chain/releases/tag/v1.1.1) - 2023-05-08
 

--- a/x/bundles/keeper/logic_bundles.go
+++ b/x/bundles/keeper/logic_bundles.go
@@ -280,14 +280,6 @@ func (k Keeper) registerBundleProposalFromUploader(ctx sdk.Context, msg *types.M
 		CompressionId:     pool.CurrentCompressionId,
 	}
 
-	// Emit a vote event.
-	_ = ctx.EventManager().EmitTypedEvent(&types.EventBundleVote{
-		PoolId:    msg.PoolId,
-		Staker:    msg.Staker,
-		StorageId: msg.StorageId,
-		Vote:      types.VOTE_TYPE_VALID,
-	})
-
 	k.SetBundleProposal(ctx, bundleProposal)
 
 	_ = ctx.EventManager().EmitTypedEvent(&types.EventBundleProposed{
@@ -305,6 +297,14 @@ func (k Keeper) registerBundleProposalFromUploader(ctx sdk.Context, msg *types.M
 		ProposedAt:        uint64(ctx.BlockTime().Unix()),
 		StorageProviderId: bundleProposal.StorageProviderId,
 		CompressionId:     bundleProposal.CompressionId,
+	})
+
+	// Emit a vote event. Uploader automatically votes valid on the own bundle.
+	_ = ctx.EventManager().EmitTypedEvent(&types.EventBundleVote{
+		PoolId:    msg.PoolId,
+		Staker:    msg.Staker,
+		StorageId: msg.StorageId,
+		Vote:      types.VOTE_TYPE_VALID,
 	})
 }
 

--- a/x/bundles/keeper/logic_bundles.go
+++ b/x/bundles/keeper/logic_bundles.go
@@ -299,7 +299,7 @@ func (k Keeper) registerBundleProposalFromUploader(ctx sdk.Context, msg *types.M
 		CompressionId:     bundleProposal.CompressionId,
 	})
 
-	// Emit a vote event. Uploader automatically votes valid on the own bundle.
+	// Emit a vote event. Uploader automatically votes valid on their bundle.
 	_ = ctx.EventManager().EmitTypedEvent(&types.EventBundleVote{
 		PoolId:    msg.PoolId,
 		Staker:    msg.Staker,


### PR DESCRIPTION
When a bundle is uploaded the uploader automatically votes valid on the uploaded bundle without the need to submit an extra transaction (or message). However, in this case the VoteEvent got emitted before the BundleProposed event. This PR swaps the event emission.