### PR TITLE
fix: CLI use correct args amount for tx redelegate

### DIFF
--- a/x/delegation/client/cli/tx_redelegate.go
+++ b/x/delegation/client/cli/tx_redelegate.go
@@ -13,7 +13,7 @@ func CmdRedelegate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redelegate [from_staker] [to_staker] [amount]",
 		Short: "Redelegate the given amount from one staker to another",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argAmount, err := cast.ToUint64E(args[2])
 			if err != nil {


### PR DESCRIPTION
There was a typo in the args-amount for the redelegate tx cli which made it impossible to create a redelegate transaction from the CLI.