### PR TITLE
fix: properly add delegation rewards in account assets query

### DIFF
--- a/x/query/keeper/grpc_account_assets.go
+++ b/x/query/keeper/grpc_account_assets.go
@@ -56,7 +56,7 @@ func (k Keeper) AccountAssets(goCtx context.Context, req *types.QueryAccountAsse
 		staker := string(delegatorIterator.Key()[0:43])
 
 		response.ProtocolDelegation += k.delegationKeeper.GetDelegationAmountOfDelegator(ctx, staker, req.Address)
-		response.ProtocolRewards.Add(k.delegationKeeper.GetOutstandingRewards(ctx, staker, req.Address)...)
+		response.ProtocolRewards = response.ProtocolRewards.Add(k.delegationKeeper.GetOutstandingRewards(ctx, staker, req.Address)...)
 	}
 
 	// ======================================================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of protocol rewards assignment in account assets retrieval, ensuring more reliable data for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->