### PR TITLE
chore(migration-proofs): Crosnest

### DIFF
--- a/app/upgrades/v2_0/validator-proofs/mainnet/Crosnest.json
+++ b/app/upgrades/v2_0/validator-proofs/mainnet/Crosnest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Crosnest",
+  "consensus_address": "kyvevaloper199403h5jgfr64r9ewv83zx7q4xphhc4wku8mer",
+  "protocol_address": "kyve199403h5jgfr64r9ewv83zx7q4xphhc4wyv8mhp",
+  "proof_1": "2BD728A325BF325949EDB5B21855455EE723B0D304F32612E7CC190B02A8D3F6",
+  "proof_2": "2BD728A325BF325949EDB5B21855455EE723B0D304F32612E7CC190B02A8D3F6"
+}


### PR DESCRIPTION
proof_1 and prof_2 are the same because protocol and consensus wallets are the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Added a new validator configuration file for Crosnest
	- Includes consensus and protocol address details for network validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->