### PR TITLE
chore: improve storage cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 An '!' indicates a state machine breaking change.
 
+## Unreleased
+
+### Improvements
+
+- ! [#266](https://github.com/KYVENetwork/chain/pull/266) Improve storage cost payout.
+
 ## [v2.1.0](https://github.com/KYVENetwork/chain/releases/tag/v2.1.0) - 2025-04-29
 
 ### Improvements

--- a/proto/kyve/delegation/v1beta1/tx.proto
+++ b/proto/kyve/delegation/v1beta1/tx.proto
@@ -8,11 +8,10 @@ import "cosmos_proto/cosmos.proto";
 option go_package = "github.com/KYVENetwork/chain/x/stakers/types_delegation_v1beta1";
 
 /*
-  NOTICE:
-  This file needs to be kept for backwards compatibility with the governance module.
-  Otherwise, it is not possible to decode legacy delegation param update proposals.
+   NOTICE:
+   This file needs to be kept for backwards compatibility with the governance module.
+   Otherwise, it is not possible to decode legacy delegation param update proposals.
 */
-
 
 // Msg defines the Msg service.
 service Msg {

--- a/x/bundles/keeper/keeper_suite_inflation_splitting_test.go
+++ b/x/bundles/keeper/keeper_suite_inflation_splitting_test.go
@@ -1512,12 +1512,21 @@ var _ = Describe("inflation splitting", Ordered, func() {
 		// for kyve coin (7410 - (7410 * 0.01) - _((100 * 0.5) / (3 * 1))_) * 0.1 + _((100 * 0.5) / (3 * 1))_
 		// for acoin (10_000 - (10_000 * 0.01) - _((100 * 0.5) / (3 * 1))_) * 0.1 + _((100 * 0.5) / (3 * 1))_
 		// for bcoin coins (20_000 - (20_000 * 0.01) - _((100 * 0.5) / (3 * 2))_) * 0.1 + _((100 * 0.5) / (3 * 2))_
-		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(748), i.ACoin(1004), i.BCoin(1987)).String()))
+
+		// STORAGE COST UPDATE: with $KYVE being used first for storage cost the kyve amount is higher for the uploader
+		// commission rewards and the amount of the other coins are lower because the uploader reward includes the storage
+		// cost (if kyve is used first the contribution of the remaining coins will be lower)
+		// VALUES BEFORE: 1004acoin,1987bcoin,748tkyve
+		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(778), i.ACoin(990), i.BCoin(1980)).String()))
 		// assert uploader self delegation rewards (here we round up since the result of delegation rewards is the remainder minus the truncated commission rewards)
 		// for kyve coin (7410 - (7410 * 0.01) - _((100 * 0.5) / (3 * 1))_) * (1 - 0.1)
 		// for acoin (10_000 - (10_000 * 0.01) - _((100 * 0.5) / (3 * 1))_) * (1 - 0.1)
 		// for bcoin (20_000 - (20_000 * 0.01) - _((100 * 0.5) / (3 * 2))_) * (1 - 0.1)
-		Expect(s.App().StakersKeeper.GetOutstandingRewards(s.Ctx(), i.STAKER_0, i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(6588), i.ACoin(8896), i.BCoin(17813)).String()))
+
+		// STORAGE COST UPDATE: with $KYVE being used first for storage cost the delegators receive less kyve and more
+		// of the remaining coins
+		// VALUES BEFORE: 8896acoin,17813bcoin,6588tkyve
+		Expect(s.App().StakersKeeper.GetOutstandingRewards(s.Ctx(), i.STAKER_0, i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(6558), i.ACoin(8910), i.BCoin(17820)).String()))
 
 		fundingState, _ := s.App().FundersKeeper.GetFundingState(s.Ctx(), 0)
 
@@ -1622,12 +1631,21 @@ var _ = Describe("inflation splitting", Ordered, func() {
 		// for kyve coin (24720 - (24720 * 0.01) - _((100 * 0.5) / (3 * 1))_) * 0.1 + _((100 * 0.5) / (3 * 1))_
 		// for acoin (10_000 - (10_000 * 0.01) - _((100 * 0.5) / (3 * 1))_) * 0.1 + _((100 * 0.5) / (3 * 1))_
 		// for bcoin coins (20_000 - (20_000 * 0.01) - _((100 * 0.5) / (3 * 2))_) * 0.1 + _((100 * 0.5) / (3 * 2))_
-		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(2461), i.ACoin(1004), i.BCoin(1987)).String()))
+
+		// STORAGE COST UPDATE: with $KYVE being used first for storage cost the kyve amount is higher for the uploader
+		// commission rewards and the amount of the other coins are lower because the uploader reward includes the storage
+		// cost (if kyve is used first the contribution of the remaining coins will be lower)
+		// VALUES BEFORE: 1004acoin,1987bcoin,2461tkyve
+		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(2492), i.ACoin(990), i.BCoin(1980)).String()))
 		// assert uploader self delegation rewards (here we round up since the result of delegation rewards is the remainder minus the truncated commission rewards)
 		// for kyve coin (24720 - (24720 * 0.01) - _((100 * 0.5) / (3 * 1))_) * (1 - 0.1)
 		// for acoin (10_000 - (10_000 * 0.01) - _((100 * 0.5) / (3 * 1))_) * (1 - 0.1)
 		// for bcoin (20_000 - (20_000 * 0.01) - _((100 * 0.5) / (3 * 2))_) * (1 - 0.1)
-		Expect(s.App().StakersKeeper.GetOutstandingRewards(s.Ctx(), i.STAKER_0, i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(22012), i.ACoin(8896), i.BCoin(17813)).String()))
+
+		// STORAGE COST UPDATE: with $KYVE being used first for storage cost the delegators receive less kyve and more
+		// of the remaining coins
+		// VALUES BEFORE: 8896acoin,17813bcoin,22012tkyve
+		Expect(s.App().StakersKeeper.GetOutstandingRewards(s.Ctx(), i.STAKER_0, i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(21981), i.ACoin(8910), i.BCoin(17820)).String()))
 
 		fundingState, _ := s.App().FundersKeeper.GetFundingState(s.Ctx(), 0)
 

--- a/x/bundles/keeper/keeper_suite_valid_bundles_test.go
+++ b/x/bundles/keeper/keeper_suite_valid_bundles_test.go
@@ -1957,10 +1957,19 @@ var _ = Describe("valid bundles", Ordered, func() {
 		// (amount_per_bundle - treasury_reward - storage_cost) * uploader_commission + storage_cost
 		// storage_cost = 1MB * storage_price / coin_length * coin_price
 		// (amount_per_bundle - (amount_per_bundle * 0.01) - _((1048576 * 0.000000006288 * 10**coin_decimals) / (4 * coin_weight))_) * 0.1 + _((1048576 * 0.000000006288) / (4 * coin_weight))_
-		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), poolAccountUploader.Staker).String()).To(Equal(sdk.NewCoins(i.KYVECoin(125_973), i.ACoin(99_143), i.BCoin(116_661_015_771_428_571), i.CCoin(100_765)).String()))
+
+		// STORAGE COST UPDATE: with $KYVE being used first for storage cost the kyve amount is higher for the uploader
+		// commission rewards and the amount of the other coins are lower because the uploader reward includes the storage
+		// cost (if kyve is used first the contribution of the remaining coins will be lower)
+		// VALUES BEFORE: 99_143acoin,116_661_015_771_428_571bcoin,100_765ccoin,125_973tkyve
+		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), poolAccountUploader.Staker).String()).To(Equal(sdk.NewCoins(i.KYVECoin(87_012), i.ACoin(99_000), i.BCoin(99_000_163_885_714_285), i.CCoin(99_000)).String()))
 		// assert uploader self delegation rewards (here we round up since the result of delegation rewards is the remainder minus the truncated commission rewards)
 		// (amount_per_bundle - (amount_per_bundle * 0.01) - _((29970208 * 0.000000006288 * 1**coin_decimals) / (4 * coin_weight))_) * (1 - 0.1)
-		Expect(s.App().StakersKeeper.GetOutstandingRewards(s.Ctx(), i.STAKER_0, i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(864_027), i.ACoin(890_857), i.BCoin(873_338_984_228_571_429), i.CCoin(889_235)).String()))
+
+		// STORAGE COST UPDATE: with $KYVE being used first for storage cost the delegators receive less kyve and more
+		// of the remaining coins
+		// VALUES BEFORE: 890_857acoin,873_338_984_228_571_429bcoin,889_235ccoin,864_027tkyve
+		Expect(s.App().StakersKeeper.GetOutstandingRewards(s.Ctx(), i.STAKER_0, i.STAKER_0).String()).To(Equal(sdk.NewCoins(i.KYVECoin(783_108), i.ACoin(891_000), i.BCoin(890_999_836_114_285_715), i.CCoin(891_000)).String()))
 
 		fundingState, _ := s.App().FundersKeeper.GetFundingState(s.Ctx(), 0)
 

--- a/x/bundles/keeper/keeper_suite_valid_bundles_test.go
+++ b/x/bundles/keeper/keeper_suite_valid_bundles_test.go
@@ -1962,7 +1962,7 @@ var _ = Describe("valid bundles", Ordered, func() {
 		// commission rewards and the amount of the other coins are lower because the uploader reward includes the storage
 		// cost (if kyve is used first the contribution of the remaining coins will be lower)
 		// VALUES BEFORE: 99_143acoin,116_661_015_771_428_571bcoin,100_765ccoin,125_973tkyve
-		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), poolAccountUploader.Staker).String()).To(Equal(sdk.NewCoins(i.KYVECoin(87_012), i.ACoin(99_000), i.BCoin(99_000_163_885_714_285), i.CCoin(99_000)).String()))
+		Expect(s.App().StakersKeeper.GetOutstandingCommissionRewards(s.Ctx(), poolAccountUploader.Staker).String()).To(Equal(sdk.NewCoins(i.KYVECoin(206_892), i.ACoin(99_000), i.BCoin(99_000_163_885_714_285), i.CCoin(99_000)).String()))
 		// assert uploader self delegation rewards (here we round up since the result of delegation rewards is the remainder minus the truncated commission rewards)
 		// (amount_per_bundle - (amount_per_bundle * 0.01) - _((29970208 * 0.000000006288 * 1**coin_decimals) / (4 * coin_weight))_) * (1 - 0.1)
 

--- a/x/bundles/keeper/logic_bundles.go
+++ b/x/bundles/keeper/logic_bundles.go
@@ -269,12 +269,10 @@ func (k Keeper) calculatePayouts(ctx sdk.Context, poolId uint64, totalPayout sdk
 	whitelist := k.fundersKeeper.GetCoinWhitelistMap(ctx)
 	storageCost := k.GetStorageCost(ctx, bundleProposal.StorageProviderId).MulInt64(int64(bundleProposal.DataSize))
 
-	kyveCoinFound, kyveCoin := totalPayout.Find(globalTypes.Denom)
-
 	kyveWeight := whitelist[globalTypes.Denom].CoinWeight
 	kyveCurrencyUnit := math.LegacyNewDec(10).Power(uint64(whitelist[globalTypes.Denom].CoinDecimals))
 
-	if kyveCoinFound && !kyveWeight.IsZero() {
+	if found, _ := totalPayout.Find(globalTypes.Denom); found && !kyveWeight.IsZero() {
 		kyveAmount := sdk.NewCoins(sdk.NewCoin(globalTypes.Denom, storageCost.Mul(kyveCurrencyUnit).Quo(kyveWeight).TruncateInt()))
 		bundleReward.UploaderStorageCost = totalPayout.Min(kyveAmount)
 		totalPayout = totalPayout.Sub(bundleReward.UploaderStorageCost...)
@@ -292,7 +290,7 @@ func (k Keeper) calculatePayouts(ctx sdk.Context, poolId uint64, totalPayout sdk
 		}
 	}
 
-	kyveCoinFound, kyveCoin = totalPayout.Find(globalTypes.Denom)
+	kyveCoinFound, kyveCoin := totalPayout.Find(globalTypes.Denom)
 	remainingCoins := totalPayout
 	if kyveCoinFound {
 		remainingCoins = totalPayout.Sub(kyveCoin)

--- a/x/bundles/keeper/logic_bundles.go
+++ b/x/bundles/keeper/logic_bundles.go
@@ -287,6 +287,8 @@ func (k Keeper) calculatePayouts(ctx sdk.Context, poolId uint64, totalPayout sdk
 
 		if storageCost.GTE(storageCostPaidUsd) {
 			storageCost = storageCost.Sub(storageCostPaidUsd)
+		} else {
+			storageCost = math.LegacyZeroDec()
 		}
 	}
 
@@ -321,10 +323,11 @@ func (k Keeper) calculatePayouts(ctx sdk.Context, poolId uint64, totalPayout sdk
 
 		// we take the min here since there can be the case where we want to charge more coins for the storage
 		// reward than we have left in the total payout
-		bundleReward.UploaderStorageCost = totalPayout.Min(wantedStorageRewards)
+		multiCoinStorageCostReward := totalPayout.Min(wantedStorageRewards)
+		bundleReward.UploaderStorageCost = bundleReward.UploaderStorageCost.Add(multiCoinStorageCostReward...)
 
 		// the remaining total payout is split between the uploader and his delegators.
-		totalPayout = totalPayout.Sub(bundleReward.UploaderStorageCost...)
+		totalPayout = totalPayout.Sub(multiCoinStorageCostReward...)
 		if totalPayout.IsZero() {
 			return
 		}


### PR DESCRIPTION
This PR used the native $KYVE coin first to pay for the storage cost and only uses the remaining coins if $KYVE is not enough. This results in uploaders receiving more $KYVE with which they can pay for Turbo storage fees and delegators receiving more foreign coins which they receive by staking $KYVE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reward distribution to prioritize using KYVE tokens for storage costs before other coins, resulting in adjusted commission and delegation rewards for uploaders and delegators.
  * Adjusted test cases to reflect the new storage cost handling and updated expected reward values accordingly.

* **Style**
  * Improved comment formatting for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->