### PR TITLE
fix: correctly export policy in genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ An '!' indicates a state machine breaking change.
 
 ### Improvements
 
-- ! [#266](https://github.com/KYVENetwork/chain/pull/266) Improve storage cost payout.
+- ! (`x/bundles`) [#266](https://github.com/KYVENetwork/chain/pull/266) Improve storage cost payout.
+
+### Bug Fixes
+
+- (`x/multi_coin_rewards`) [#269](https://github.com/KYVENetwork/chain/pull/269) Correctly export policy in genesis.
 
 ## [v2.1.0](https://github.com/KYVENetwork/chain/releases/tag/v2.1.0) - 2025-04-29
 

--- a/x/multi_coin_rewards/genesis.go
+++ b/x/multi_coin_rewards/genesis.go
@@ -23,6 +23,11 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	}
 
 	k.SetQueueState(ctx, types.QUEUE_IDENTIFIER_MULTI_COIN_REWARDS, genState.QueueStatePendingRewards)
+
+	err := k.MultiCoinDistributionPolicy.Set(ctx, *genState.MultiCoinDistributionPolicy)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // ExportGenesis returns the capability module's exported genesis.

--- a/x/multi_coin_rewards/keeper/msg_server_distribution_policy_test.go
+++ b/x/multi_coin_rewards/keeper/msg_server_distribution_policy_test.go
@@ -128,8 +128,9 @@ var _ = Describe("msg_server_distribution_policy_test.go", Ordered, func() {
 
 		// ASSERT
 		Expect(err.Error()).To(Equal("duplicate entry for denom acoin"))
-		_, err = s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
-		Expect(err).NotTo(BeNil())
+		policy, err := s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
+		Expect(err).To(BeNil())
+		Expect(policy.Entries).To(HaveLen(0))
 	})
 
 	It("Invalid Policy: Duplicate pool entries for same denom", func() {
@@ -167,8 +168,9 @@ var _ = Describe("msg_server_distribution_policy_test.go", Ordered, func() {
 
 		// ASSERT
 		Expect(err.Error()).To(Equal("duplicate distribution weight for pool id 0"))
-		_, err = s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
-		Expect(err).NotTo(BeNil())
+		policy, err := s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
+		Expect(err).To(BeNil())
+		Expect(policy.Entries).To(HaveLen(0))
 	})
 
 	It("Invalid Policy: Negative weights", func() {
@@ -194,8 +196,9 @@ var _ = Describe("msg_server_distribution_policy_test.go", Ordered, func() {
 
 		// ASSERT
 		Expect(err.Error()).To(Equal("invalid weight for pool id 0"))
-		_, err = s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
-		Expect(err).NotTo(BeNil())
+		policy, err := s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
+		Expect(err).To(BeNil())
+		Expect(policy.Entries).To(HaveLen(0))
 	})
 
 	It("Invalid Policy: Zero weights", func() {
@@ -221,7 +224,8 @@ var _ = Describe("msg_server_distribution_policy_test.go", Ordered, func() {
 
 		// ASSERT
 		Expect(err.Error()).To(Equal("invalid weight for pool id 0"))
-		_, err = s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
-		Expect(err).NotTo(BeNil())
+		policy, err := s.App().MultiCoinRewardsKeeper.MultiCoinDistributionPolicy.Get(s.Ctx())
+		Expect(err).To(BeNil())
+		Expect(policy.Entries).To(HaveLen(0))
 	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.

- Bug Fixes
  - Correctly initializes and exports the multi-coin rewards distribution policy from genesis, preventing inconsistent state after chain start or export/import cycles.

- Documentation
  - Updated changelog to clarify an existing improvement and record the bug fix.

- Tests
  - Revised tests to validate policy retrieval and empty state after invalid updates, ensuring predictable behavior without relying on retrieval errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->